### PR TITLE
Fixed Reply To Functionality

### DIFF
--- a/Service_SMTP2Go/README.md
+++ b/Service_SMTP2Go/README.md
@@ -10,6 +10,18 @@ Should look similar to this:
 vars.txt - The variables used in the template and formatted for SMTP2Go  
 service.ps1 - The Powershell document to notify about, and automatically restart the service with notification
 
+# Setup
+- Create an SMTP2Go account and fulfil setup with verified Sender domain. [Get Started - SMTP2GO Documentation](https://support.smtp2go.com/hc/en-gb/articles/12747932085145-Getting-Started-with-SMTP2GO)  
+- Add Template to SMTP2Go using HTML from `index.html` in this repo.  Note the "Template ID" [API Templates](https://support.smtp2go.com/hc/en-gb/articles/4402929434777-API-Templates)
+- Set up an API Key [API Keys](https://support.smtp2go.com/hc/en-gb/articles/20733554340249-API-Keys)
+- Clone this Repo or download `Service.ps1` and edit the script whith the appropriate information
+    - Monitored Service Name
+    - From Name and Email
+    - Recipient Email
+    - Reply-To Name eand Email (If applicable)
+    - API Key
+    - Template ID
+Set script to run on a schedule using your preferred method
 
 # Original E-mail Template is from:
 https://github.com/leemunroe/responsive-html-email-template


### PR DESCRIPTION
Adjusted the script so that the Reply-To headers are added if defined.  I also added the Name to the email sender and Reply To sections, this required adding a couple of variables.  An "If" only adds the "Custom Headers" array if those variables are used.  They are commented out by default. 

I adjust the variable section into a "Config Area" and put all of the static stuff below a "Do not touch" line.